### PR TITLE
fixed import error of detect_NaN

### DIFF
--- a/src/loftr/loftr.py
+++ b/src/loftr/loftr.py
@@ -6,7 +6,7 @@ from .backbone import build_backbone
 from .loftr_module import LocalFeatureTransformer, FinePreprocess
 from .utils.coarse_matching import CoarseMatching
 from .utils.fine_matching import FineMatching
-from src.utils.misc import detect_NaN
+from ..utils.misc import detect_NaN
 
 from loguru import logger
 


### PR DESCRIPTION
I had some trouble importing the detect_NaN function from src.utils.misc, so i changed the way of importing it. 